### PR TITLE
javascript: when building with emsdk-portable, make sure we use the c…

### DIFF
--- a/ports/javascript/Makefile
+++ b/ports/javascript/Makefile
@@ -14,6 +14,10 @@ INC += -I$(TOP)
 INC += -I$(BUILD)
 
 CPP = clang -E
+ifdef EMSCRIPTEN
+    CPP += -isystem $(EMSCRIPTEN)/system/include/libc -cxx-isystem $(EMSCRIPTEN)/system/include/libcxx
+endif
+
 CFLAGS = -m32 $(INC) -Wall -Werror -std=c99 $(COPT)
 LDFLAGS = -m32 -Wl,-Map=$@.map,--cref -Wl,--gc-sections
 


### PR DESCRIPTION
…orrect header files